### PR TITLE
(11.5.0) Pulling out variables into config.xml file

### DIFF
--- a/TestServers.py
+++ b/TestServers.py
@@ -2,20 +2,26 @@ import yaml
 
 class TestServers(object):
 
-    @staticmethod
-    def get_roles(server):
-        roles = TestServers.init_roles()
+    @classmethod
+    def get_roles(_self, server):
+        roles = _self.init_roles()
         try:
             return roles[server]
         except Exception as e: 
             return 'Failed to find role: {0}. error: {1}'.format(server, e)
 
-    @staticmethod
-    def get_server_names():
-        roles = TestServers.init_roles()
+    @classmethod
+    def get_server_names(_self):
+        roles = _self.init_roles()
         return [role_name for role_name, role_list in roles.iteritems()]
 
-    @staticmethod
-    def init_roles():
-        with open('/opt/ecs_review_job/roles.yml', 'r') as roles:
+    @classmethod
+    def init_roles(_self):
+        config = _self.get_configs()
+        with open(config['roles_path'], 'r') as roles:
             return yaml.load(roles)
+
+    @staticmethod
+    def get_configs():
+        with open('config.yml', 'r') as configs:
+            return yaml.load(configs)

--- a/config.yml
+++ b/config.yml
@@ -1,1 +1,15 @@
-# This will be the general config file
+# Set equal to the name of your Autoscaling Group, requires setting a tag with key: 'Name' and value: 'XXX'
+autoscaling_group_name: 'jenkins_ec2_autoscaling_group'
+
+# Set equal to the max number of attempts, each attempt is separated by 30s
+attempt_limit: 80
+
+#Set equal to the absolute path location of your roles.yml file
+roles_path: './roles.yml'
+
+#Set equal to your aws profile
+profile_name: 'default'
+
+#Set equal to the first 5 characters of your ecs Cluster name (from jenkinsTemplate.py ecs_cluster())
+#TODO: INFRASYS-6745
+cluster_name: 'jenki'

--- a/launch_review_job.py
+++ b/launch_review_job.py
@@ -15,10 +15,13 @@ class ReviewJob(object):
 
     ECS = 'ecs'
     EC2 = 'ec2'
+    CONFIGS = TestServers.get_configs()
+    PROFILE = CONFIGS['profile_name']
     AUTOSCALING = 'autoscaling'
-    AUTOSCALING_GROUP_NAME = 'jenkins_ec2_autoscaling_group'
+    AUTOSCALING_GROUP_NAME = CONFIGS["autoscaling_group_name"]
     TEST_SERVERS = TestServers.get_server_names()
-    ATTEMPT_LIMIT = 80 # 40 minutes
+    ATTEMPT_LIMIT = CONFIGS['attempt_limit']
+    CLUSTER_NAME = CONFIGS['cluster_name']
 
     logging.basicConfig(level=logging.INFO)
     log = logging.getLogger(__name__)
@@ -36,7 +39,7 @@ class ReviewJob(object):
         self.init_instance()
 
     def init_boto_clients(self):
-        session = Session(profile_name=self.ECS)
+        session = Session(profile_name=self.PROFILE)
         self.ecs_client = self.get_boto_client(session, self.ECS)
         self.autoscaling_client = self.get_boto_client(session, self.AUTOSCALING)
         self.ec2_client = self.get_boto_client(session, self.EC2)
@@ -208,7 +211,7 @@ class ReviewJob(object):
         clusters = self.ecs_client.list_clusters()
         cluster_arns = clusters['clusterArns']
         for cluster_arn in cluster_arns:
-            if 'jenki' in cluster_arn:
+            if self.CLUSTER_NAME in cluster_arn:
                 return cluster_arn
 
     def launch_instance(self):


### PR DESCRIPTION
Below is test run, killed before complete but it did fire up the instance

gfogelberg salt-integration-testing (INFRASYS-6463)\* |-(o)-| python launch_review_job.py ${JOB_NAME} ${BUILD_NUMBER} ${IP_ADDR}
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
INFO:botocore.vendored.requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): ecs.us-east-1.amazonaws.com
INFO:botocore.vendored.requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): autoscaling.us-east-1.amazonaws.com
INFO:**main**:Launching instance
INFO:**main**:No new instance found. Waiting 10 seconds before checking again
INFO:**main**:No new instance found. Waiting 10 seconds before checking again
INFO:**main**:New instance has launched: ['i-20581db8']
INFO:botocore.vendored.requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): ec2.us-east-1.amazonaws.com
INFO:**main**:i-20581db8 private ip: 10.24.20.000
INFO:**main**:Waiting 10 seconds for instance to become active
INFO:**main**:Waiting 10 seconds for instance to become active
INFO:**main**:Waiting 60 seconds before checking if new instance is in the cluster
INFO:botocore.vendored.requests.packages.urllib3.connectionpool:Resetting dropped connection: ecs.us-east-1.amazonaws.com
INFO:**main**:New instance not in cluster yet. Must give it another shot...
INFO:**main**:Waiting 30 seconds before checking if new instance is in the cluster
INFO:**main**:Instance successfully registered into cluster
INFO:**main**:Starting tasks
INFO:**main**:Tasks are still running. Waiting for 30 seconds
INFO:**main**:Tasks are still running. Waiting for 30 seconds
INFO:**main**:Tasks are still running. Waiting for 30 seconds
INFO:**main**:Tasks are still running. Waiting for 30 seconds
INFO:**main**:Tasks are still running. Waiting for 30 seconds
