### PR TITLE
(BSD2016-04) INFRASYS-7159 fixes setup.py to properly install all modules on a fresh clone

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,6 @@
 exclude_lines =
     if __name__ == .__main__.:
 
-omit = custom*
+omit = 
+    custom*
+    setup*

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The following assumptions are made in utilizing this project:
   * Add unit tests to new code
   * Ensure all unit tests pass and coverage has not dropped
     ```
-    python setup.py nosetests
+    python setup.py test
     ```
 
   * To check coverage, you can run:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto3
-PyYaml
+pyaml
 troposphere
 redis

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,25 @@
 #!/usr/bin/env python
 
 import os
-from custom_install import CustomInstall
-from custom_coverage import CustomCoverage
 from setuptools import setup
+import troposphere
 
 def read(file_name):
     return open(os.path.join(os.path.dirname(__file__), file_name)).read()
 
-install_requires = [
-    read('requirements.txt')
-]
+def get_cmdclass(needs_install):
+    if needs_install:
+        return {}
+    return {'troposphere': CustomInstall, 'coverage': CustomCoverage}
 
-tests_require = [
-    read('tests/requirements.txt')
-]
+install_requires = read('requirements.txt').split()
+tests_require = read('tests/requirements.txt').split()
 
+needs_install = not os.path.isdir('build')
+
+if not needs_install: 
+    from custom_install import CustomInstall
+    from custom_coverage import CustomCoverage
 
 setup(
     name="SIT",
@@ -28,9 +32,9 @@ setup(
     url="https://github.com/dandb/salt-integration-testing",
     packages=['sit'],
     include_package_data=True,
-    cmdclass={'troposphere': CustomInstall, 'coverage': CustomCoverage},
+    cmdclass=get_cmdclass(needs_install),
     install_requires=install_requires,
     tests_require=tests_require,
-    test_suite="tests/*",
+    test_suite="nose.collector",
     long_description=read('README.md') + '\n\n' + read('CHANGES'),
 )

--- a/tests/infrastructure/sit_loader_test.py
+++ b/tests/infrastructure/sit_loader_test.py
@@ -1,0 +1,17 @@
+import unittest
+from mock import MagicMock
+
+from infrastructure.sit_loader import SITLoader
+from infrastructure.sit_template import SITTemplate
+from helpers.cf_helper import CFHelper
+
+
+class SITLoaderTest(unittest.TestCase):
+    
+    def setUp(self):
+        configs_directory = 'tests/sit/configs'
+        self.sit_loader = SITLoader(configs_directory)
+        self.cf_helper = CFHelper()
+        self.cf_helper.get_stack_info = MagicMock(return_value=True)
+        self.sit_template = SITTemplate(configs_directory)
+

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 nose
 placebo
 boto3
-PyYaml
+pyaml
 mock
 troposphere

--- a/tests/sit/ecs_container_test.py
+++ b/tests/sit/ecs_container_test.py
@@ -1,0 +1,18 @@
+import unittest
+
+from sit.ecs_container import Container
+
+
+class UserDataTest(unittest.TestCase):
+    
+    def setUp(self):
+        self.container = Container()
+        self.container.master_ip = '1.2.3.4'
+        self.container.env = 'qa'
+        self.container.family = 'test'
+        self.container.role = 'unit'
+        self.container.MEMORY = 10
+
+    def test_environment_dictionary(self):
+        result = self.container.get_environment_dictionary('test', 'value')
+        self.assertEquals(result, {"name": 'test', "value": 'value'})


### PR DESCRIPTION
This fixes the chicken and egg origin problem.
Custom scripts require modules that setup.py install has not yet had a chance to install.

Proof of it working:
```bash
(venv2.6) ➜  sit git:(INFRASYS-7159) ✗ rm -rf build 
(venv2.6) ➜  sit git:(INFRASYS-7159) ✗ python setup.py troposphere
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'troposphere'
(venv2.6) ➜  sit git:(INFRASYS-7159) ✗ python setup.py install
running install
running bdist_egg
running egg_info
writing requirements to SIT.egg-info/requires.txt
writing SIT.egg-info/PKG-INFO
writing top-level names to SIT.egg-info/top_level.txt
writing dependency_links to SIT.egg-info/dependency_links.txt
reading manifest file 'SIT.egg-info/SOURCES.txt'
writing manifest file 'SIT.egg-info/SOURCES.txt'
installing library code to build/bdist.macosx-10.9-intel/egg
running install_lib
running build_py
creating build
creating build/lib
creating build/lib/sit
copying sit/__init__.py -> build/lib/sit
copying sit/check_sit.py -> build/lib/sit
copying sit/ecs_container.py -> build/lib/sit
copying sit/launch_review_job.py -> build/lib/sit
copying sit/redis_client.py -> build/lib/sit
creating build/bdist.macosx-10.9-intel
creating build/bdist.macosx-10.9-intel/egg
creating build/bdist.macosx-10.9-intel/egg/sit
copying build/lib/sit/__init__.py -> build/bdist.macosx-10.9-intel/egg/sit
copying build/lib/sit/check_sit.py -> build/bdist.macosx-10.9-intel/egg/sit
copying build/lib/sit/ecs_container.py -> build/bdist.macosx-10.9-intel/egg/sit
copying build/lib/sit/launch_review_job.py -> build/bdist.macosx-10.9-intel/egg/sit
copying build/lib/sit/redis_client.py -> build/bdist.macosx-10.9-intel/egg/sit
byte-compiling build/bdist.macosx-10.9-intel/egg/sit/__init__.py to __init__.pyc
byte-compiling build/bdist.macosx-10.9-intel/egg/sit/check_sit.py to check_sit.pyc
byte-compiling build/bdist.macosx-10.9-intel/egg/sit/ecs_container.py to ecs_container.pyc
byte-compiling build/bdist.macosx-10.9-intel/egg/sit/launch_review_job.py to launch_review_job.pyc
byte-compiling build/bdist.macosx-10.9-intel/egg/sit/redis_client.py to redis_client.pyc
creating build/bdist.macosx-10.9-intel/egg/EGG-INFO
copying SIT.egg-info/PKG-INFO -> build/bdist.macosx-10.9-intel/egg/EGG-INFO
copying SIT.egg-info/SOURCES.txt -> build/bdist.macosx-10.9-intel/egg/EGG-INFO
copying SIT.egg-info/dependency_links.txt -> build/bdist.macosx-10.9-intel/egg/EGG-INFO
copying SIT.egg-info/requires.txt -> build/bdist.macosx-10.9-intel/egg/EGG-INFO
copying SIT.egg-info/top_level.txt -> build/bdist.macosx-10.9-intel/egg/EGG-INFO
zip_safe flag not set; analyzing archive contents...
creating 'dist/SIT-0.0.1-py2.6.egg' and adding 'build/bdist.macosx-10.9-intel/egg' to it
removing 'build/bdist.macosx-10.9-intel/egg' (and everything under it)
Processing SIT-0.0.1-py2.6.egg
Removing /Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages/SIT-0.0.1-py2.6.egg
Copying SIT-0.0.1-py2.6.egg to /Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages
SIT 0.0.1 is already the active version in easy-install.pth

Installed /Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages/SIT-0.0.1-py2.6.egg
Processing dependencies for SIT==0.0.1
Searching for redis==2.10.5
Best match: redis 2.10.5
Adding redis 2.10.5 to easy-install.pth file

Using /Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages
Searching for troposphere==1.5.0
Best match: troposphere 1.5.0
Processing troposphere-1.5.0-py2.6.egg
troposphere 1.5.0 is already the active version in easy-install.pth
Installing cfn2py script to /Users/sbraverman/Sites/salt-config/venv2.6/bin
Installing cfn script to /Users/sbraverman/Sites/salt-config/venv2.6/bin

Using /Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages/troposphere-1.5.0-py2.6.egg
Searching for pyaml==15.8.2
Best match: pyaml 15.8.2
Processing pyaml-15.8.2-py2.6.egg
pyaml 15.8.2 is already the active version in easy-install.pth

Using /Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages/pyaml-15.8.2-py2.6.egg
Searching for boto3==1.2.5
Best match: boto3 1.2.5
Adding boto3 1.2.5 to easy-install.pth file

Using /Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages
Searching for PyYAML==3.11
Best match: PyYAML 3.11
Processing PyYAML-3.11-py2.6-macosx-10.9-intel.egg
PyYAML 3.11 is already the active version in easy-install.pth

Using /Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages/PyYAML-3.11-py2.6-macosx-10.9-intel.egg
Searching for botocore==1.3.30
Best match: botocore 1.3.30
Adding botocore 1.3.30 to easy-install.pth file

Using /Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages
Searching for futures==3.0.5
Best match: futures 3.0.5
Adding futures 3.0.5 to easy-install.pth file

Using /Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages
Searching for jmespath==0.9.0
Best match: jmespath 0.9.0
Adding jmespath 0.9.0 to easy-install.pth file

Using /Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages
Searching for docutils==0.12
Best match: docutils 0.12
Adding docutils 0.12 to easy-install.pth file

Using /Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages
Searching for python-dateutil==2.5.0
Best match: python-dateutil 2.5.0
Adding python-dateutil 2.5.0 to easy-install.pth file

Using /Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages
Searching for simplejson==3.3.0
Best match: simplejson 3.3.0
Adding simplejson 3.3.0 to easy-install.pth file

Using /Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages
Searching for ordereddict==1.1
Best match: ordereddict 1.1
Adding ordereddict 1.1 to easy-install.pth file

Using /Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages
Searching for six==1.10.0
Best match: six 1.10.0
Adding six 1.10.0 to easy-install.pth file

Using /Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages
Finished processing dependencies for SIT==0.0.1
(venv2.6) ➜  sit git:(INFRASYS-7159) ✗ python setup.py troposphere
running troposphere
running build
running build_py
running egg_info
writing requirements to SIT.egg-info/requires.txt
writing SIT.egg-info/PKG-INFO
writing top-level names to SIT.egg-info/top_level.txt
writing dependency_links to SIT.egg-info/dependency_links.txt
reading manifest file 'SIT.egg-info/SOURCES.txt'
writing manifest file 'SIT.egg-info/SOURCES.txt'
running install_lib
running install_egg_info
removing '/Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages/SIT-0.0.1-py2.6.egg-info' (and everything under it)
Copying SIT.egg-info to /Users/sbraverman/Sites/salt-config/venv2.6/lib/python2.6/site-packages/SIT-0.0.1-py2.6.egg-info
running install_scripts
2016-04-17 02:20:04,329: INFO: Found credentials in shared credentials file: ~/.aws/credentials
2016-04-17 02:20:04,350: INFO: Found credentials in shared credentials file: ~/.aws/credentials
2016-04-17 02:20:04,367: INFO: Found credentials in shared credentials file: ~/.aws/credentials
2016-04-17 02:20:04,468: INFO: Starting new HTTPS connection (1): cloudformation.us-west-1.amazonaws.com
2016-04-17 02:20:04,666: ERROR: Message: The stack "sit-tool" already exists. Error: None. Code: 2
```