### PR TITLE
INFRASYS-7592: Change SIT to autoscale ECS Instances on demand 

### DIFF
--- a/configs/sit.yml
+++ b/configs/sit.yml
@@ -5,8 +5,8 @@ attempt_limit: 80
 profile_name: 'default'
 
 # Docker container configs
-container_memory: 512
-container_cpu: 512
+container_memory: 1024
+container_cpu: 1024
 container_image: 'dandb/salt_review:2015-8-7'
 
 # Logfile configs

--- a/configs/troposphere.yml
+++ b/configs/troposphere.yml
@@ -25,6 +25,9 @@ autoscaling_group_name: 'sitAutoScalingGroup'
 subnet:
 max_size: 20
 min_size: 0
+scaling_metric: 'CPUReservation'
+scale_up_threshold: '70'
+scale_down_threshold: '20'
 
 ## General configs
 tag_key: 'Name'

--- a/helpers/sit_template_helper.py
+++ b/helpers/sit_template_helper.py
@@ -3,7 +3,6 @@
 import logging
 import subprocess
 
-from helpers.cf_helper import CFHelper
 from helpers.ec2_helper import EC2Helper
 from helpers.sit_helper import SITHelper
 from helpers.log import Log
@@ -19,12 +18,7 @@ class SITTemplateHelper(object):
         self.AMI_URL = self.configs['ami_url']
         self.SECURITY_GROUPS = self.configs['security_groups']
         self.SUBNET = self.configs['subnet']
-        self.cf_helper = CFHelper(configs_directory=configs_directory, session=session)
         self.ec2_helper = EC2Helper(configs_directory=configs_directory, session=session)
-    
-    def validate_stack_exists(self):
-        if self.cf_helper.stack_exists(self.STACK_NAME):
-            Log.error('The stack "{0}" already exists'.format(self.STACK_NAME))
 
     def validate_configs(self):
         logging.info('Validating configs')
@@ -51,7 +45,6 @@ class SITTemplateHelper(object):
         Log.error('{0} "{1}" not found. Please update configs/troposphere.yml'.format(resource_name, resource))
 
     def validate(self):
-        self.validate_stack_exists()
         self.validate_configs()
         self.validate_aws_resources()
     

--- a/infrastructure/sit_loader.py
+++ b/infrastructure/sit_loader.py
@@ -28,8 +28,11 @@ class SITLoader(object):
     def validate_template(self):
         self.cf_helper.validate_template(self.template_json)
 
-    def create_stack(self):
-        self.cf_helper.create_stack(self.STACK_NAME, self.template_json, self.TAG_VALUE)
+    def create_or_update_stack(self):
+        if self.cf_helper.stack_exists(self.STACK_NAME):
+            self.cf_helper.update_stack(self.STACK_NAME, self.template_json, self.TAG_VALUE)
+        else:
+            self.cf_helper.create_stack(self.STACK_NAME, self.template_json, self.TAG_VALUE)
 
     def stack_created_successfully(self):
         if not self.cf_helper.stack_was_created_successfully(self.STACK_NAME):
@@ -38,7 +41,7 @@ class SITLoader(object):
     def run(self):
         start = time()
         self.validate_template()
-        self.create_stack()
+        self.create_or_update_stack()
         self.stack_created_successfully()
         end = time()
         logging.info('Your stack is up and ready to go!')

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if not needs_install:
 
 setup(
     name="salt-sit",
-    version="0.0.1",
+    version="0.0.2",
     author="Dun and Bradstreet",
     author_email="sit.dandb@gmail.com",
     description=('Salt Integration Testing Tool -- applies role configurations to Docker container minions using AWS (Amazon Web Services) ECS (EC2 Container Service)'),

--- a/tests/helpers/cf_helper_test.py
+++ b/tests/helpers/cf_helper_test.py
@@ -28,13 +28,25 @@ class CFHelperTest(unittest.TestCase):
         negative_result = self.cf_helper_placebo.validate_template(template_body)
         self.assertEquals(negative_result, None)
 
-    @raises(SystemExit)
-    def test_create_stack(self):
+    def test_create_stack_success(self):
         positive_result = self.cf_helper_placebo.create_stack(self.sit_loader_placebo.STACK_NAME, self.sit_loader_placebo.template_json, self.sit_loader_placebo.TAG_VALUE)
         self.assertEquals(positive_result, None)
 
-        #this call will raise the SystemExit because the stack has already been created
+    def test_update_stack_success(self):
+        positive_result = self.cf_helper_placebo.update_stack(self.sit_loader_placebo.STACK_NAME, self.sit_loader_placebo.template_json, self.sit_loader_placebo.TAG_VALUE)
+        self.assertEquals(positive_result, None)
+
+    @raises(SystemExit)
+    def test_create_stack_failure(self):
+        positive_result = self.cf_helper_placebo.create_stack(self.sit_loader_placebo.STACK_NAME, self.sit_loader_placebo.template_json, self.sit_loader_placebo.TAG_VALUE)
+        self.assertEquals(positive_result, None)
         self.cf_helper_placebo.create_stack(self.sit_loader_placebo.STACK_NAME, self.sit_loader_placebo.template_json, self.sit_loader_placebo.TAG_VALUE)
+
+    @raises(SystemExit)
+    def test_update_stack_failure(self):
+        positive_result = self.cf_helper_placebo.update_stack(self.sit_loader_placebo.STACK_NAME, self.sit_loader_placebo.template_json, self.sit_loader_placebo.TAG_VALUE)
+        self.assertEquals(positive_result, None)
+        self.cf_helper_placebo.update_stack(self.sit_loader_placebo.STACK_NAME, self.sit_loader_placebo.template_json, self.sit_loader_placebo.TAG_VALUE)
 
     def test_stack_was_created_successfully(self):
         attempts = 25  # set attempts to the max so that it only tries once

--- a/tests/helpers/sit_template_helper_test.py
+++ b/tests/helpers/sit_template_helper_test.py
@@ -27,11 +27,6 @@ class SitHelperTest(unittest.TestCase):
         self.sit_template_helper.validate()
 
     @raises(SystemExit)
-    def test_validate_stack_exists_fails(self):
-        self.sit_template_helper.cf_helper.stack_exists = MagicMock(return_value=True)
-        self.assertRaises(self.sit_template_helper.validate_stack_exists(), Exception)
-
-    @raises(SystemExit)
     def test_validate_configs(self):
         sit_template_helper = self.get_sit_template_helper('empty_configs')
         self.assertRaises(sit_template_helper.validate_configs(), Exception)

--- a/tests/helpers/test_data/cloudformation.UpdateStack_1.json
+++ b/tests/helpers/test_data/cloudformation.UpdateStack_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200, 
+    "data": {
+        "StackId": "arn:aws:cloudformation:us-west-1:12345:stack/sit-tool-test/stack-id",
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "12345-request-id"
+        }
+    }
+}

--- a/tests/helpers/test_data/cloudformation.UpdateStack_2.json
+++ b/tests/helpers/test_data/cloudformation.UpdateStack_2.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 400,
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 400,
+            "RequestId": "12345-request-id"
+        },
+        "Error": {
+            "Message": "Failed to update stack sit-tool-test",
+            "Code": "ValidationError",
+            "Type": "Sender"
+        }
+    }
+}

--- a/tests/infrastructure/sit_loader_test.py
+++ b/tests/infrastructure/sit_loader_test.py
@@ -17,8 +17,9 @@ class SITLoaderTest(unittest.TestCase):
 
     def mock_cf_helper_true_responses(self):
         cf_helper = CFHelper(configs_directory=self.configs_directory, session=self.session)
-        cf_helper.get_stack_info = MagicMock(return_value=True)
+        cf_helper.get_stack_info = MagicMock(return_value=False)
         cf_helper.validate_template = MagicMock(return_value=True)
+        cf_helper.create_or_update_stack = MagicMock(return_value=True)
         cf_helper.create_stack = MagicMock(return_value=True)
         cf_helper.stack_was_created_successfully = MagicMock(return_value=True)
         self.sit_loader.cf_helper = cf_helper

--- a/tests/sit/configs/troposphere.yml
+++ b/tests/sit/configs/troposphere.yml
@@ -25,6 +25,9 @@ autoscaling_group_name: 'sitAutoScalingGroup'
 subnet: subnet-fakesubnet
 max_size: 20
 min_size: 0
+scaling_metric: 'CPUReservation'
+scale_up_threshold: '70'
+scale_down_threshold: '20'
 
 ## General configs
 tag_key: 'Name'

--- a/tests/sit/test_data/ecs.DescribeTasks_2.json
+++ b/tests/sit/test_data/ecs.DescribeTasks_2.json
@@ -23,7 +23,7 @@
                         }
                     ]
                 },
-                "lastStatus": "RUNNING",
+                "lastStatus": "STOPPED",
                 "desiredStatus": "string",
                 "containers": [
                     {

--- a/tests/sit/test_data/ecs.ListContainerInstances_2.json
+++ b/tests/sit/test_data/ecs.ListContainerInstances_2.json
@@ -1,7 +1,9 @@
 {
     "status_code": 200, 
     "data": {
-        "containerInstanceArns": [],
+        "containerInstanceArns": [
+            "arn:container-instance"
+        ],
         "ResponseMetadata": {
             "HTTPStatusCode": 200, 
             "RequestId": "1ad3fc-0a877-954fd57"

--- a/tests/sit/test_data/ecs.RunTask_1.json
+++ b/tests/sit/test_data/ecs.RunTask_1.json
@@ -1,6 +1,7 @@
 {
     "status_code": 200, 
     "data": {
+        "failures": [{"reason": "RESOURCE:CPU"}],
         "tasks": [
             {
                 "taskArn": "string",

--- a/tests/sit/test_data/ecs.RunTask_2.json
+++ b/tests/sit/test_data/ecs.RunTask_2.json
@@ -1,6 +1,7 @@
 {
-    "status_code": 200,
+    "status_code": 200, 
     "data": {
+        "failures": [],
         "tasks": [
             {
                 "taskArn": "string",
@@ -23,14 +24,14 @@
                         }
                     ]
                 },
-                "lastStatus": "RUNNING",
+                "lastStatus": "string",
                 "desiredStatus": "string",
                 "containers": [
                     {
                         "containerArn": "string",
                         "taskArn": "string",
                         "name": "string",
-                        "lastStatus": "STOPPED",
+                        "lastStatus": "string",
                         "exitCode": 123,
                         "reason": "string",
                         "networkBindings": [
@@ -45,12 +46,6 @@
                 ],
                 "startedBy": "string",
                 "stoppedReason": "string"
-            }
-        ],
-        "failures": [
-            {
-                "arn": "string",
-                "reason": "string"
             }
         ]
     },


### PR DESCRIPTION
* Create Cloud Watch Alarms based on CPURegistration Metric
* Added feature to update a stack 
* Modified SIT logic to initially scale an instance, but leave the autoscaling after that to AWS. 
* Removed code that was manually scaling up/down instances in ASG
* Added code to make tasks wait for RESOURCES to be available in ECS Cluster in case the Alarm takes some time kick in.
* Added Unit Tests for new code - Removed Unit Tests for old code.