### PR TITLE
(14.2.0) DEVOPS-7733: Add a Task Clean Up Wait duration configuration option

### DIFF
--- a/configs/troposphere.yml
+++ b/configs/troposphere.yml
@@ -28,6 +28,7 @@ min_size: 0
 scaling_metric: 'CPUReservation'
 scale_up_threshold: '70'
 scale_down_threshold: '20'
+ecs_task_cleanup_wait_duration: '20m'
 
 ## General configs
 tag_key: 'Name'

--- a/infrastructure/sit_template.py
+++ b/infrastructure/sit_template.py
@@ -30,6 +30,7 @@ class SITTemplate(object):
         self.SCALING_METRIC = configs['scaling_metric']
         self.SCALE_UP_THRESHOLD = configs['scale_up_threshold']
         self.SCALE_DOWN_THRESHOLD = configs['scale_down_threshold']
+        self.ECS_TASK_CLEANUP_WAIT = configs['ecs_task_cleanup_wait_duration']
         self.template = Template()
         self.user_data = UserData(configs_directory)
         self.init_template()
@@ -97,9 +98,11 @@ class SITTemplate(object):
 
         commands = {
             '01_add_instance_to_cluster': {
-                'command': Join('', ['#!/bin/bash\n', 'echo ECS_CLUSTER=', Ref(ecs_cluster), ' >> /etc/ecs/ecs.config'])
-            }   
-        }    
+                'command': Join('', ['#!/bin/bash\n', 'echo ECS_CLUSTER=', Ref(ecs_cluster),
+                                     '$"\n"ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION=', self.ECS_TASK_CLEANUP_WAIT,
+                                     ' >> /etc/ecs/ecs.config'])
+            }
+        }
 
         files = {
             "/etc/cfn/cfn-hup.conf": {

--- a/tests/helpers/configs/troposphere.yml
+++ b/tests/helpers/configs/troposphere.yml
@@ -25,6 +25,7 @@ autoscaling_group_name: 'sitAutoScalingGroup'
 subnet: subnet-fakesubnet
 max_size: 20
 min_size: 0
+ecs_task_cleanup_wait_duration: '20m'
 
 ## General configs
 tag_key: 'Name'

--- a/tests/sit/configs/troposphere.yml
+++ b/tests/sit/configs/troposphere.yml
@@ -28,6 +28,7 @@ min_size: 0
 scaling_metric: 'CPUReservation'
 scale_up_threshold: '70'
 scale_down_threshold: '20'
+ecs_task_cleanup_wait_duration: '20m'
 
 ## General configs
 tag_key: 'Name'

--- a/tests/sit/test_data/autoscaling.DescribeAutoScalingGroups_1.json
+++ b/tests/sit/test_data/autoscaling.DescribeAutoScalingGroups_1.json
@@ -1,54 +1,24 @@
 {
-    "status_code": 200, 
+    "status_code": 200,
     "data": {
         "AutoScalingGroups": [
             {
-                "AutoScalingGroupARN": "arn:aws:autoscaling",
-                "HealthCheckGracePeriod": 0,
-                "SuspendedProcesses": [],
-                "DesiredCapacity": 2,
-                "EnabledMetrics": [],
-                "LoadBalancerNames": [],
+                "DesiredCapacity": 0,
                 "AutoScalingGroupName": "test-asg",
                 "DefaultCooldown": 300,
                 "MinSize": 0,
-                "Instances": [
-                    {
-                        "InstanceId": "i-87ac3d44",
-                        "AvailabilityZone": "us-west-1a",
-                        "HealthStatus": "Healthy",
-                        "LifecycleState": "InService",
-                        "LaunchConfigurationName": "sit-tool-sitLaunchConfiguration-1W5MQIFDSZBU7"
-                    },
-                    {
-                        "InstanceId": "i-a10f9c62",
-                        "AvailabilityZone": "us-west-1a",
-                        "HealthStatus": "Healthy",
-                        "LifecycleState": "InService",
-                        "LaunchConfigurationName": "sit-tool-sitLaunchConfiguration-1W5MQIFDSZBU7"
-                    }
-                ],
+                "Instances": [],
                 "MaxSize": 20,
                 "VPCZoneIdentifier": "subnet-test",
                 "TerminationPolicies": [
                     "Default"
                 ],
                 "LaunchConfigurationName": "sit-tool-sitLaunchConfiguration",
-                "CreatedTime": {
-                    "hour": 20,
-                    "__class__": "datetime",
-                    "month": 3,
-                    "second": 30,
-                    "microsecond": 441000,
-                    "year": 2016,
-                    "day": 28,
-                    "minute": 39
-                },
                 "HealthCheckType": "EC2"
             }
         ],
         "ResponseMetadata": {
-            "HTTPStatusCode": 200, 
+            "HTTPStatusCode": 200,
             "RequestId": "57b8d900-05b5-11e6-a25b-3101b4af54f3"
         }
     }

--- a/tests/sit/test_data/autoscaling.DescribeAutoScalingGroups_2.json
+++ b/tests/sit/test_data/autoscaling.DescribeAutoScalingGroups_2.json
@@ -1,0 +1,56 @@
+
+{
+    "status_code": 200,
+    "data": {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupARN": "arn:aws:autoscaling",
+                "HealthCheckGracePeriod": 0,
+                "SuspendedProcesses": [],
+                "DesiredCapacity": 2,
+                "EnabledMetrics": [],
+                "LoadBalancerNames": [],
+                "AutoScalingGroupName": "test-asg",
+                "DefaultCooldown": 300,
+                "MinSize": 0,
+                "Instances": [
+                    {
+                        "InstanceId": "i-87ac3d44",
+                        "AvailabilityZone": "us-west-1a",
+                        "HealthStatus": "Healthy",
+                        "LifecycleState": "InService",
+                        "LaunchConfigurationName": "sit-tool-sitLaunchConfiguration-1W5MQIFDSZBU7"
+                    },
+                    {
+                        "InstanceId": "i-a10f9c62",
+                        "AvailabilityZone": "us-west-1a",
+                        "HealthStatus": "Healthy",
+                        "LifecycleState": "InService",
+                        "LaunchConfigurationName": "sit-tool-sitLaunchConfiguration-1W5MQIFDSZBU7"
+                    }
+                ],
+                "MaxSize": 20,
+                "VPCZoneIdentifier": "subnet-test",
+                "TerminationPolicies": [
+                    "Default"
+                ],
+                "LaunchConfigurationName": "sit-tool-sitLaunchConfiguration",
+                "CreatedTime": {
+                    "hour": 20,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 30,
+                    "microsecond": 441000,
+                    "year": 2016,
+                    "day": 28,
+                    "minute": 39
+                },
+                "HealthCheckType": "EC2"
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "57b8d900-05b5-11e6-a25b-3101b4af54f3"
+        }
+    }
+}

--- a/tests/sit/test_data/ecs.ListContainerInstances_2.json
+++ b/tests/sit/test_data/ecs.ListContainerInstances_2.json
@@ -2,7 +2,7 @@
     "status_code": 200, 
     "data": {
         "containerInstanceArns": [
-            "arn:container-instance"
+            "arn:container-instance/1234"
         ],
         "ResponseMetadata": {
             "HTTPStatusCode": 200, 


### PR DESCRIPTION
Added the ecs_task_cleanup_wait_duration option to SIT.

This ensures that the ecs agent regularly cleans up after specified duration if several tasks are run on the same instance. This makes sure that the ECS instance does not run out of disk space.