### PR TITLE
(14.2.0) DEVOPS-7733: Add configuration option to specify volume size on ECS Instances

### DIFF
--- a/configs/troposphere.yml
+++ b/configs/troposphere.yml
@@ -14,10 +14,16 @@ instance_type: 'c3.4xlarge'
 security_groups:
 #  - 'sg-78shdjs'
 
+# If you are using an amazon-ecs-optimized ami older than 2015.09c use '/dev/xvda' below
+# http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
+ebs_device_name: '/dev/xvdcz'
+ebs_volume_size: 60
+
 key_name:
 # AMI ID of amazon-ecs-optimized e.g. 'ami-33679c77'
 ami_id:
 ami_url: 'https://aws.amazon.com/marketplace/search/results/ref=dtl_navgno_search_box?page=1&searchTerms=Amazon+ECS-Optimized+Amazon+Linux+AMI'
+
 
 ## Autoscaling Group configs
 autoscaling_group_name: 'sitAutoScalingGroup'
@@ -25,10 +31,14 @@ autoscaling_group_name: 'sitAutoScalingGroup'
 subnet:
 max_size: 20
 min_size: 0
+
+#ECS Agent Configs
+ecs_task_cleanup_wait_duration: '20m'
+
+## Cloudwatch Alarm Configs
 scaling_metric: 'CPUReservation'
 scale_up_threshold: '70'
 scale_down_threshold: '20'
-ecs_task_cleanup_wait_duration: '20m'
 
 ## General configs
 tag_key: 'Name'

--- a/infrastructure/sit_template.py
+++ b/infrastructure/sit_template.py
@@ -21,6 +21,8 @@ class SITTemplate(object):
         self.TAG_KEY = configs["tag_key"]
         self.TAG_VALUE = configs["tag_value"]
         self.AMI_ID = configs['ami_id']
+        self.EBS_VOLUME_SIZE = configs['ebs_volume_size']
+        self.EBS_DEVICE_NAME = configs['ebs_device_name']
         self.MAX_SIZE = configs['max_size']
         self.MIN_SIZE = configs['min_size']
         self.SUBNET = configs['subnet']
@@ -159,7 +161,14 @@ class SITTemplate(object):
                             services=services
                         )
                     })
-                )
+                ),
+                BlockDeviceMappings=[autoscaling.BlockDeviceMapping(
+                    DeviceName=self.EBS_DEVICE_NAME,
+                    Ebs=autoscaling.EBSBlockDevice(
+                        DeleteOnTermination=True,
+                        VolumeSize=self.EBS_VOLUME_SIZE
+                    )
+                )]
             )
         )
 

--- a/tests/helpers/configs/troposphere.yml
+++ b/tests/helpers/configs/troposphere.yml
@@ -13,6 +13,8 @@ instance_type: 'c3.4xlarge'
 # array of security group IDs. Example is shown
 security_groups:
   - 'sg-78shdjs'
+ebs_device_name: '/dev/xvdcz'
+ebs_volume_size: 60
 
 key_name: fake-key
 # AMI ID of amazon-ecs-optimized e.g. 'ami-33679c77'

--- a/tests/sit/configs/troposphere.yml
+++ b/tests/sit/configs/troposphere.yml
@@ -13,6 +13,8 @@ instance_type: 'c3.4xlarge'
 # array of security group IDs. Example is shown
 security_groups:
   - 'sg-78shdjs'
+ebs_device_name: '/dev/xvdcz'
+ebs_volume_size: 60
 
 key_name: fake-key
 # AMI ID of amazon-ecs-optimized e.g. 'ami-33679c77'


### PR DESCRIPTION
Updated config with `ebs_volume_size=60` and applied cloud formation changes to test region using `python setup.py troposphere` command
Confirmed Volume Size that is used by docker below: (This is for amazon-ecs-optimized ami > 2015.09c)
```
[root@ip-x-x-x-x ~]# vgs
  VG     #PV #LV #SN Attr   VSize  VFree  
  docker   1   1   0 wz--n- 60.00g 552.00m
```