### PR TITLE
(14.4.0) DEVOPS-7727: Increase initial SIT cluster size and clean up tasks if review job times out.

### DIFF
--- a/infrastructure/sit_template.py
+++ b/infrastructure/sit_template.py
@@ -166,7 +166,8 @@ class SITTemplate(object):
                     DeviceName=self.EBS_DEVICE_NAME,
                     Ebs=autoscaling.EBSBlockDevice(
                         DeleteOnTermination=True,
-                        VolumeSize=self.EBS_VOLUME_SIZE
+                        VolumeSize=self.EBS_VOLUME_SIZE,
+                        VolumeType='gp2'
                     )
                 )]
             )

--- a/tests/sit/launch_review_job_test.py
+++ b/tests/sit/launch_review_job_test.py
@@ -56,3 +56,16 @@ class LaunchReviewJobTest(unittest.TestCase):
         self.assertEquals(launch_review.highstate_failed(result), True)
         result_false = "foo bar"
         self.assertEquals(launch_review.highstate_failed(result_false), False)
+
+    @patch.object(ReviewJob, 'check_sit', return_value=None)
+    @patch.object(ReviewJob, 'get_cluster', return_value='test-cluster')
+    @patch.object(ReviewJob, 'get_autoscaling_group', return_value='test-asg')
+    def test_wait_for_tasks_to_complete_timeout(self, *args):
+        launch_review = ReviewJob('test', '1', '1.2.3.4', configs_directory='tests/sit/configs', session=self.session)
+        launch_review.cluster = 'sit-tool-test-sitClusterTest'
+        launch_review.running_task_ids = ['arn:aws:ecs:us-west-1:123:task/123456']
+        launch_review.ATTEMPT_LIMIT = 4
+        try:
+            launch_review.wait_for_tasks_to_complete(attempt=5)
+        except SystemExit as se:
+            self.assertEquals(se.code, 2)

--- a/tests/sit/test_data/ecs.StopTask_1.json
+++ b/tests/sit/test_data/ecs.StopTask_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "task": {
+            "taskArn": "arn:aws:ecs:us-west-1:123:task/123456",
+            "lastStatus": "RUNNING", 
+            "containerInstanceArn": "arn:aws:ecs:us-west-1:1234:container-instance/1234",
+            "clusterArn": "arn:aws:ecs:us-west-1:1234:cluster/sit-tool-test-sitClusterTest",
+            "desiredStatus": "STOPPED", 
+            "stoppedReason": "Task stopped by user", 
+            "taskDefinitionArn": "arn:aws:ecs:us-west-1:54321:task-definition/apple_review-3-fruits:2"
+        }, 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "76cc9503-7593-11e6-96de-7178042921da"
+        }
+    }
+}


### PR DESCRIPTION
**Tested Task Termination after limit as follows:**
Updated attempt_limit to 2: 
```
[root@ip-x-x-x-x salt-integration-testing]# cat configs/sit.yml 
# Max number of attempts used for task run-time, each attempt is separated by 30s
attempt_limit: 2

# aws profile
profile_name: 'sit'...
```

**Ran Sit:**
```
[root@ip-x-x-x-x salt-integration-testing]# python -m sit.launch_review_job fruit-test 51 x.x.x.x /srv/salt-integration-testing/configs/
2016-09-08 08:46:37,565: INFO: Found credentials in shared credentials file: ~/.aws/credentials
2016-09-08 08:46:37,929: INFO: Starting new HTTPS connection (1): cloudformation.us-west-1.amazonaws.com
2016-09-08 08:46:38,115: INFO: Found credentials in shared credentials file: ~/.aws/credentials
2016-09-08 08:46:38,138: INFO: Found credentials in shared credentials file: ~/.aws/credentials
2016-09-08 08:46:38,383: INFO: Starting new HTTPS connection (1): cloudformation.us-west-1.amazonaws.com
2016-09-08 08:46:38,783: INFO: Starting new HTTPS connection (1): autoscaling.us-west-1.amazonaws.com
2016-09-08 08:46:38,862: INFO: Current SIT Cluster capacity: 0
2016-09-08 08:46:38,862: INFO: Cluster is currently empty. Launching instances.
2016-09-08 08:46:38,927: INFO: Starting new HTTPS connection (1): ecs.us-west-1.amazonaws.com
2016-09-08 08:46:38,981: INFO: First instance not in cluster yet. Waiting for 30 seconds...
2016-09-08 08:47:09,031: INFO: First instance not in cluster yet. Waiting for 30 seconds...
2016-09-08 08:47:39,071: INFO: First instance not in cluster yet. Waiting for 30 seconds...
2016-09-08 08:48:09,159: INFO: First instance not in cluster yet. Waiting for 30 seconds...
2016-09-08 08:48:39,219: INFO: SIT Cluster Instance Ids: [u'i-1234', u'i-1234']
2016-09-08 08:48:39,221: INFO: Starting new HTTPS connection (1): ec2.us-west-1.amazonaws.com
2016-09-08 08:48:39,377: INFO: SIT Cluster Instance IPs: ['x.x.x.x']
2016-09-08 08:48:39,507: INFO: Starting tasks: ['fruit-test-51-fruit1', 'fruit-test-51-fruit2']
2016-09-08 08:48:39,719: INFO: 2 Tasks are still running. Waiting for 30 seconds
2016-09-08 08:49:09,772: INFO: 2 Tasks are still running. Waiting for 30 seconds
2016-09-08 08:49:39,828: INFO: 2 Tasks are still running. Waiting for 30 seconds
2016-09-08 08:50:09,857: INFO: 2 attempts have gone by. Initiating termination sequence
2016-09-08 08:50:09,983: INFO: Termination Complete. Following Tasks have been killed : [u'arn:aws:ecs:us-west-1:#######:task-definition/fruit-test-51-fruit1:1', u'arn:aws:ecs:us-west-1:xxxxxxxx:task-definition/fruit-test-51-fruit2:1']. Exception: None
```