### PR TITLE
(17.12.0) DEVOPS-8723 adds ability to set redis_host to something other than same value as master. Falls back to master ip if not provided

### DIFF
--- a/docker/minion.conf
+++ b/docker/minion.conf
@@ -8,6 +8,6 @@ master: {{ MASTER }}
 
 ext_job_cache: redis
 redis.db: '0'
-redis.host: '{{ MASTER }}'
+redis.host: '{{ REDIS_HOST }}'
 redis.port: 6379
 

--- a/docker/setupAndRunHighstate.sh
+++ b/docker/setupAndRunHighstate.sh
@@ -14,6 +14,7 @@ sed -i "s/{{ ROLES }}/- $roles/" minion
 sed -i "s/,/\n    - /g" minion 
 sed -i "s/{{ MINION_ID }}/$minion_id/" minion
 sed -i "s/{{ ENV }}/$env/" minion
+sed -i "s/{{ REDIS_HOST }}/$redis_host/" minion
 
 # Since we are modifying the minion config, we need to restart salt
 /sbin/service salt-minion restart 

--- a/sit/ecs_container.py
+++ b/sit/ecs_container.py
@@ -3,7 +3,7 @@ from helpers.sit_helper import SITHelper
 
 class Container(object):
 
-    def __init__(self, configs_directory=None, family=None, role=None, master_ip=None, env='local'):
+    def __init__(self, configs_directory=None, family=None, role=None, master_ip=None, env='local', redis_host=None):
         self.sit_helper = SITHelper(configs_directory)
         sit_configs = self.sit_helper.get_configs('sit')
         self.MEMORY = sit_configs['container_memory']
@@ -14,6 +14,7 @@ class Container(object):
         self.role = role
         self.master_ip = master_ip
         self.env = env
+        self.redis_host = self.generate_redis_host(master_ip, redis_host)
 
     def get_container_definitions(self):
         return {
@@ -31,7 +32,12 @@ class Container(object):
         environment_variables.append(Container.get_environment_dictionary('env', self.env))
         environment_variables.append(Container.get_environment_dictionary('master', self.master_ip))
         environment_variables.append(Container.get_environment_dictionary('minion_id', self.family))
+        environment_variables.append(Container.get_environment_dictionary('redis_host', self.redis_host))
         return environment_variables
+
+    @staticmethod
+    def generate_redis_host(master_ip, redis_host):
+        return redis_host if redis_host else master_ip
 
     @staticmethod
     def get_environment_dictionary(name, value):

--- a/sit/launch_review_job.py
+++ b/sit/launch_review_job.py
@@ -43,6 +43,7 @@ class ReviewJob(object):
         self.INITIAL_CLUSTER_SIZE = sit_configs['initial_cluster_size']
         self.SAVE_LOGS = sit_configs['save_logs']
         self.HIGHSTATE_LOG_DIR = sit_configs['highstate_log_dir']
+        self.REDIS_HOST = sit_configs.get('redis_host', None)
         self.cf_helper = CFHelper(configs_directory=configs_directory, session=session)
         self.family = self.join_items([job_name, build_number])
         self.master_ip = master_ip
@@ -139,7 +140,7 @@ class ReviewJob(object):
             self.error('Failed to register tasks for family: {0}, role: {1}'.format(family, role), e)
 
     def get_container_definitions(self, role, family):
-        container = Container(configs_directory=self.configs_directory, env='local', role=role, family=family, master_ip=self.master_ip)
+        container = Container(configs_directory=self.configs_directory, env='local', role=role, family=family, master_ip=self.master_ip, redis_host=self.REDIS_HOST)
         return container.get_container_definitions()
 
     def start_tasks(self, tasks):
@@ -192,7 +193,7 @@ class ReviewJob(object):
             self.error('Failed to retrieve tasks from cluster.', e)
 
     def check_and_print_results(self):
-        redis_client = RedisClient()
+        redis_client = RedisClient(self.REDIS_HOST)
         for role in self.ROLES:
             family = self.join_items([self.family, role])
             highstate_result = redis_client.get_highstate_result(family)

--- a/sit/redis_client.py
+++ b/sit/redis_client.py
@@ -9,8 +9,8 @@ class RedisClient(object):
 
     HIGHSTATE = 'state.highstate'
 
-    def __init__(self):
-        self.redis_instance = self.connect_redis()
+    def __init__(self, host='localhost'):
+        self.redis_instance = self.connect_redis(host=host)
 
     def connect_redis(self,  host='localhost', port=6379, timeout=2):
         try:

--- a/tests/sit/ecs_container_test.py
+++ b/tests/sit/ecs_container_test.py
@@ -8,15 +8,15 @@ from helpers.sit_helper import SITHelper
 class UserDataTest(unittest.TestCase):
     
     def setUp(self):
-        configs_directory = 'tests/sit/configs'
-        self.container = Container(configs_directory)
-        self.container.master_ip = '1.2.3.4'
-        self.container.env = 'qa'
-        self.container.family = 'test'
-        self.container.role = 'unit'
-        self.container.MEMORY = 10
-        self.container.sit_helper = SITHelper(configs_directory)
-        self.container.sit_helper.get_states_for_role = MagicMock(return_value=['server', 'php'])
+        self.configs_directory = 'tests/sit/configs'
+        self.container = self.create_container()
+
+    def create_container(self, redis_host=None):
+        container = Container(configs_directory=self.configs_directory,
+                              redis_host=redis_host, master_ip='1.2.3.4', env='qa', family='test', role='unit')
+        container.MEMORY = 10
+        container.sit_helper.get_states_for_role = MagicMock(return_value=['server', 'php'])
+        return container
 
     def test_environment_dictionary(self):
         result = self.container.get_environment_dictionary('test', 'value')
@@ -24,5 +24,11 @@ class UserDataTest(unittest.TestCase):
 
     def test_get_environment_variables(self):
         result = self.container.get_container_definitions()
-        expected_answer = {'memoryReservation': 256, 'name': 'test', 'image': 'dandb/salt_review:2015-8-7', 'environment': [{'name': 'roles', 'value': 'server,php'}, {'name': 'env', 'value': 'qa'}, {'name': 'master', 'value': '1.2.3.4'}, {'name': 'minion_id', 'value': 'test'}], 'memory': 10, 'cpu': 512}
+        expected_answer = {'memoryReservation': 256, 'name': 'test', 'image': 'dandb/salt_review:2015-8-7', 'environment': [{'name': 'roles', 'value': 'server,php'}, {'name': 'env', 'value': 'qa'}, {'name': 'master', 'value': '1.2.3.4'}, {'name': 'minion_id', 'value': 'test'}, {'name': 'redis_host', 'value': '1.2.3.4'}], 'memory': 10, 'cpu': 512}
+        self.assertEquals(result, expected_answer)
+
+    def test_get_environment_varuables_with_redis_hist(self):
+        container = self.create_container(redis_host='localhost')
+        result = container.get_container_definitions()
+        expected_answer = {'memoryReservation': 256, 'name': 'test', 'image': 'dandb/salt_review:2015-8-7', 'environment': [{'name': 'roles', 'value': 'server,php'}, {'name': 'env', 'value': 'qa'}, {'name': 'master', 'value': '1.2.3.4'}, {'name': 'minion_id', 'value': 'test'}, {'name': 'redis_host', 'value': 'localhost'}], 'memory': 10, 'cpu': 512}
         self.assertEquals(result, expected_answer)


### PR DESCRIPTION
New Docker image has been uploaded

Need to update tests

Testing worked:
```
-bash-4.1$ python -m sit.launch_review_job brave 16 ${IP_ADDR} ${CONFIG_DIR}
2017-03-14 17:24:00,537: INFO: Found credentials in shared credentials file: ~/.aws/credentials
2017-03-14 17:24:00,813: INFO: Starting new HTTPS connection (1): cloudformation.us-west-1.amazonaws.com
2017-03-14 17:24:00,904: INFO: Found credentials in shared credentials file: ~/.aws/credentials
2017-03-14 17:24:00,950: INFO: Found credentials in shared credentials file: ~/.aws/credentials
2017-03-14 17:24:01,177: INFO: Starting new HTTPS connection (1): cloudformation.us-west-1.amazonaws.com
2017-03-14 17:24:01,268: INFO: Starting new HTTPS connection (1): autoscaling.us-west-1.amazonaws.com
2017-03-14 17:24:01,338: INFO: Current SIT Cluster capacity: 11
2017-03-14 17:24:01,339: INFO: Starting new HTTPS connection (1): ecs.us-west-1.amazonaws.com
2017-03-14 17:24:01,440: INFO: SIT Cluster Instance Ids: [u'i-0fc6c2d3d5c68a401', u'i-0a296a2ab1efd3b75', u'i-0f8efe6fb3f66b8d8', u'i-081d565db6368ba6c', u'i-0865935a9dcd9002e', u'i-08b8bf417ec37cc0b', u'i-03c1b80f210401fc9', u'i-0681ebb914d345e27', u'i-07a0e97260f282d78', u'i-0bc52f9e54b37653d', u'i-075af2250099d4f9b']
2017-03-14 17:24:01,443: INFO: Starting new HTTPS connection (1): ec2.us-west-1.amazonaws.com
2017-03-14 17:24:01,580: INFO: SIT Cluster Instance IPs: ['10.26.40.188', '10.26.40.85', '10.26.40.186', '10.26.40.47', '10.26.40.40', '10.26.40.161', '10.26.40.74', '10.26.40.219', '10.26.40.173', '10.26.40.217', '10.26.40.48']
2017-03-14 17:24:05,035: INFO: Task: brave-16-slave has started running..
2017-03-14 17:24:05,110: INFO: Task: brave-16-phoenix has started running..
2017-03-14 17:24:05,203: INFO: Task: brave-16-telesales has started running..
2017-03-14 17:24:05,274: INFO: Task: brave-16-php has started running..
2017-03-14 17:24:05,357: INFO: Task: brave-16-sftp has started running..
2017-03-14 17:24:05,437: INFO: Task: brave-16-util has started running..
2017-03-14 17:24:05,506: INFO: Task: brave-16-lb has started running..
2017-03-14 17:24:05,596: INFO: Task: brave-16-queue has started running..
2017-03-14 17:24:05,681: INFO: Task: brave-16-es has started running..
2017-03-14 17:24:05,809: INFO: Task: brave-16-rsyslog has started running..
2017-03-14 17:24:05,900: INFO: Task: brave-16-dnbi has started running..
2017-03-14 17:24:05,971: INFO: Task: brave-16-nfs has started running..
2017-03-14 17:24:06,044: INFO: Task: brave-16-cos has started running..
2017-03-14 17:24:06,133: INFO: Task: brave-16-cart has started running..
2017-03-14 17:24:06,194: INFO: Task: brave-16-dashboard has started running..
2017-03-14 17:24:06,287: INFO: Task: brave-16-owl has started running..
2017-03-14 17:24:06,333: INFO: 16 Tasks are still running. Waiting for 30 seconds
2017-03-14 17:24:36,415: INFO: 16 Tasks are still running. Waiting for 30 seconds
2017-03-14 17:25:06,499: INFO: 16 Tasks are still running. Waiting for 30 seconds
2017-03-14 17:25:36,579: INFO: 16 Tasks are still running. Waiting for 30 seconds
2017-03-14 17:26:06,663: INFO: 16 Tasks are still running. Waiting for 30 seconds
2017-03-14 17:26:36,721: INFO: 8 Tasks are still running. Waiting for 30 seconds
2017-03-14 17:27:06,780: INFO: Tasks are complete
```

```
>>> redis_client = Redis('redis-jenkins.devops.malibucoding.com')
>>> redis_client.keys('*')
['brave-16-slave:20170315002623346959', 'brave-16-nfs:state.highstate', 'brave-16-phoenix:state.highstate', 'brave-16-util:20170315002620774224', 'brave-16-telesales:state.highstate', 'brave-16-telesales:20170315002615365110', 'brave-16-queue:20170315002632748074', 'braves:test.ping', 'brave-16-rsyslog:state.highstate', 'brave-16-dashboard:state.highstate', 'brave-16-es:state.highstate', 'brave-16-cart:state.highstate', 'brave-16-php:20170315002620352032', 'braves-51:test.ping', 'braves:20170314234104955842', 'brave-16-dnbi:20170315002627011037', 'brave-16-owl:state.highstate', 'brave-16-php:state.highstate', 'brave-16-lb:state.highstate', 'braves-51:20170315000205788198', 'minions', 'brave-16-rsyslog:20170315002623556353', 'brave-16-nfs:20170315002641655176', 'brave-16-cart:20170315002630151746', 'brave-16-queue:state.highstate', 'brave-16-sftp:state.highstate', 'brave-16-util:state.highstate', 'braves-5:test.ping', 'brave-16-lb:20170315002620297830', 'brave-16-cos:20170315002610974207', 'braves-5:20170314234614138721', 'brave-16-owl:20170315002630023368', 'jids', 'brave-16-sftp:20170315002614163979', 'brave-16-dashboard:20170315002617468352', 'brave-16-es:20170315002629718187', 'brave-16-phoenix:20170315002614265201', 'brave-16-cos:state.highstate', 'brave-16-slave:state.highstate', 'brave-16-dnbi:state.highstate']
```