### PR TITLE
(17.23.0) DEVOPS-9241: Adding new failure for conflicting IDS

### DIFF
--- a/sit/launch_review_job.py
+++ b/sit/launch_review_job.py
@@ -218,7 +218,7 @@ class ReviewJob(object):
 
     def highstate_failed(self, result):
         try:
-            possible_failures = ['"result": false', 'Data failed to compile:', 'Pillar failed to render with the following messages:']
+            possible_failures = ['"result": false', 'Data failed to compile:', 'Pillar failed to render with the following messages:', 'Detected conflicting IDs']
             failures = [failure in result for failure in possible_failures]
             if True not in failures:
                 failures = self.check_regex_failure(failures, result)


### PR DESCRIPTION
Salt_review showing build failure for conflicting ids:
<img width="1412" alt="screen shot 2017-06-02 at 5 05 13 pm" src="https://cloud.githubusercontent.com/assets/588833/26748775/aa260076-47b5-11e7-9001-5920946182b8.png">
