### PR TITLE
DBCREDIT-6271: add awacs dependency to SIT

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto3
 pyaml
-troposphere
+troposphere[policy]
 redis


### PR DESCRIPTION
Testing evidence -
```
[root@aw1-slave-i0ae86ad7187089717203-ciq sit]# cat requirements.txt 
boto3
pyaml
troposphere[policy]
redis
[root@aw1-slave-i0ae86ad7187089717203-ciq sit]# 
```