### PR TITLE
DEVOPS-11080: pinning python-dateutil for 2.6 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+python-dateutil==2.6.1
 boto3
 pyaml
 troposphere[policy]==2.0.2


### PR DESCRIPTION
Observed existing python-dateutil upon creating new test agent:
```
[root@aw1-agent_default-i0737d8a073f38ca7c118-ciq ~]# pip list | grep python-dateutil
You are using pip version 7.1.0, however version 10.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
python-dateutil (1.4.1)
```

changed /opt/sit/requirements.txt on the test agent:
```
[root@aw1-agent_default-i0737d8a073f38ca7c118-ciq ~]# cat /opt/sit/requirements.txt
python-dateutil==2.6.1
boto3
pyaml
troposphere[policy]==2.0.2
redis
```

ran pip install against requirements.txt and saw expected results
```
[root@aw1-agent_default-i0737d8a073f38ca7c118-ciq ~]# pip install -r /opt/sit/requirements.txt
...
Installing collected packages: python-dateutil, pyaml, botocore
  Found existing installation: python-dateutil 1.4.1
    Uninstalling python-dateutil-1.4.1:
      Successfully uninstalled python-dateutil-1.4.1
  Found existing installation: botocore 1.6.4
    Uninstalling botocore-1.6.4:
      Successfully uninstalled botocore-1.6.4
Successfully installed botocore-1.8.50 pyaml-17.12.1 python-dateutil-2.6.1
[root@aw1-agent_default-i0737d8a073f38ca7c118-ciq ~]# pip list | grep python-dateutil
You are using pip version 7.1.0, however version 10.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
python-dateutil (2.6.1)
```
